### PR TITLE
Add product quantity selector with dynamic pricing

### DIFF
--- a/src/components/AddToCartButton.tsx
+++ b/src/components/AddToCartButton.tsx
@@ -14,6 +14,7 @@ interface AddToCartButtonProps {
   productHandle?: string;
   price?: number;
   availableForSale?: boolean;
+  quantity?: number;
   isSubscription?: boolean;
   subscriptionFrequency?: string;
   subscriptionDiscount?: number;
@@ -28,13 +29,13 @@ export default function AddToCartButton({
   productHandle = '',
   price = 0,
   availableForSale = true,
+  quantity = 1,
   isSubscription = false,
   subscriptionFrequency = 'monthly',
   subscriptionDiscount = 0,
   sellingPlanId,
   klaviyoFormId = 'RU73Kw'
 }: AddToCartButtonProps) {
-  const [quantity, setQuantity] = useState(1);
   const { addItem, isLoading } = useCart();
   
   // Initialize Klaviyo
@@ -93,36 +94,10 @@ export default function AddToCartButton({
   
   return (
     <div>
-      {/* Quantity selector - only show when product is in stock */}
-      {availableForSale && (
-        <div className="mb-6">
-          <h3 className="text-sm font-medium text-gray-900">Quantity</h3>
-          <div className="mt-2 inline-flex items-center border border-gray-900 rounded">
-            <button
-              type="button"
-              className="text-black px-4 py-2 text-lg"
-              onClick={() => setQuantity(Math.max(1, quantity - 1))}
-              disabled={quantity <= 1}
-            >
-              -
-            </button>
-            <span className="text-black px-4 py-2 text-base">
-              {quantity}
-            </span>
-            <button
-              type="button"
-              className="text-black px-4 py-2 text-lg"
-              onClick={() => setQuantity(quantity + 1)}
-            >
-              +
-            </button>
-          </div>
-        </div>
-      )}
       
       <button
         type="button"
-        className={`md:w-1/2 w-full flex items-center justify-center rounded-md border border-transparent px-16 py-3 text-base font-medium text-white focus:outline-none focus:ring-2 focus:ring-emeraldgreen-500 focus:ring-offset-2 ${
+        className={`md:w-1/2 sm:w-1/2 w-full flex items-center justify-center rounded-md border border-transparent px-16 py-3 text-base font-medium text-white focus:outline-none focus:ring-2 focus:ring-emeraldgreen-500 focus:ring-offset-2 whitespace-nowrap ${
           'bg-emeraldgreen-500 hover:bg-brightgreen-500'
         }`}
         onClick={handleAddToCart}

--- a/src/components/EnhancedProductForm.tsx
+++ b/src/components/EnhancedProductForm.tsx
@@ -8,6 +8,7 @@ import { getSubscriptionOptions } from '@/lib/shopify';
 import AddToCartButton from '@/components/AddToCartButton';
 import SubscriptionSelector, { PurchaseOption } from './SubscriptionSelector';
 import SubscriptionSelectorV2, { PurchaseOptionV2 } from './SubscriptionSelectorV2';
+import QuantitySelector from './QuantitySelector';
 
 function classNames(...classes: string[]) {
   return classes.filter(Boolean).join(" ");
@@ -33,6 +34,7 @@ export default function EnhancedProductForm({ product, onSubscriptionChange }: P
   const [selectedPurchaseOption, setSelectedPurchaseOption] = useState<PurchaseOption | null>(null);
   const [subscriptionOptions, setSubscriptionOptions] = useState<PurchaseOption[]>([]);
   const [selectedSellingPlan, setSelectedSellingPlan] = useState<SellingPlan | null>(null);
+  const [selectedQuantity, setSelectedQuantity] = useState<number>(1);
   
   // Get the first available variant ID
   const firstVariant = product.variants?.edges?.[0]?.node;
@@ -144,6 +146,12 @@ export default function EnhancedProductForm({ product, onSubscriptionChange }: P
         </div>
       )}
       
+      {/* Quantity Selector */}
+      <QuantitySelector 
+        selectedQuantity={selectedQuantity}
+        onChange={setSelectedQuantity}
+      />
+      
       {/* Subscription Options - Only show if product has subscription option */}
       {product.hasSubscriptionOption && subscriptionOptions.length > 1 && selectedPurchaseOption && (
         <SubscriptionSelectorV2 
@@ -151,6 +159,7 @@ export default function EnhancedProductForm({ product, onSubscriptionChange }: P
           selectedOption={selectedPurchaseOption}
           onChange={handlePurchaseOptionChange}
           productPrice={firstVariant?.priceV2?.amount}
+          quantity={selectedQuantity}
         />
       )}
 
@@ -162,6 +171,7 @@ export default function EnhancedProductForm({ product, onSubscriptionChange }: P
           productHandle={product.handle}
           price={price}
           availableForSale={availableForSale}
+          quantity={selectedQuantity}
           isSubscription={selectedPurchaseOption?.value === 'subscription'}
           subscriptionFrequency={selectedPurchaseOption?.deliveryFrequency}
           subscriptionDiscount={selectedPurchaseOption?.discountPercentage}

--- a/src/components/QuantitySelector.tsx
+++ b/src/components/QuantitySelector.tsx
@@ -1,0 +1,59 @@
+'use client';
+
+import { RadioGroup } from '@headlessui/react';
+
+interface QuantityOption {
+  id: string;
+  quantity: number;
+  label: string;
+  sticks: number;
+}
+
+interface QuantitySelectorProps {
+  selectedQuantity: number;
+  onChange: (quantity: number) => void;
+}
+
+const quantityOptions: QuantityOption[] = [
+  { id: '1-tin', quantity: 1, label: '1 Tin', sticks: 15 },
+  { id: '2-tins', quantity: 2, label: '2 Tins', sticks: 30 },
+  { id: '3-tins', quantity: 3, label: '3 Tins', sticks: 45 },
+];
+
+export default function QuantitySelector({ selectedQuantity, onChange }: QuantitySelectorProps) {
+  const selectedOption = quantityOptions.find(opt => opt.quantity === selectedQuantity) || quantityOptions[0];
+
+  return (
+    <div className="mb-4">
+      <RadioGroup value={selectedOption} onChange={(option) => onChange(option.quantity)}>
+        <RadioGroup.Label className="sr-only">Choose quantity</RadioGroup.Label>
+        <div className="grid grid-cols-3 gap-2 sm:gap-3">
+          {quantityOptions.map((option) => (
+            <RadioGroup.Option
+              key={option.id}
+              value={option}
+              className={({ checked }) =>
+                `relative flex cursor-pointer rounded-lg border-2 p-3 sm:p-4 focus:outline-none ${
+                  checked
+                    ? 'border-emeraldgreen-500 bg-emeraldgreen-50'
+                    : 'border-gray-300 bg-white hover:border-gray-400'
+                }`
+              }
+            >
+              {({ checked }) => (
+                <div className="flex w-full flex-col items-center justify-center text-center">
+                  <RadioGroup.Label className="text-sm sm:text-base font-semibold text-emeraldgreen-500">
+                    {option.label}
+                  </RadioGroup.Label>
+                  <RadioGroup.Description className="text-xs sm:text-sm text-gray-500 mt-1">
+                    {option.sticks} sticks
+                  </RadioGroup.Description>
+                </div>
+              )}
+            </RadioGroup.Option>
+          ))}
+        </div>
+      </RadioGroup>
+    </div>
+  );
+}

--- a/src/components/SubscriptionSelectorV2.tsx
+++ b/src/components/SubscriptionSelectorV2.tsx
@@ -20,13 +20,15 @@ interface SubscriptionSelectorV2Props {
   selectedOption: PurchaseOptionV2;
   onChange: (option: PurchaseOptionV2) => void;
   productPrice?: string;
+  quantity?: number;
 }
 
 export default function SubscriptionSelectorV2({ 
   options, 
   selectedOption, 
   onChange,
-  productPrice 
+  productPrice,
+  quantity = 1 
 }: SubscriptionSelectorV2Props) {
   
   // Format price to currency
@@ -62,14 +64,21 @@ export default function SubscriptionSelectorV2({
         
         {options.map((option) => {
           const isSubscription = option.value === 'subscription';
-          const originalPrice = productPrice || '36.00';
-          const discountedPrice = isSubscription && option.discountPercentage 
-            ? getDiscountedPrice(originalPrice, option.discountPercentage)
-            : originalPrice;
-          const perServingPrice = getPerServingPrice(discountedPrice);
-          const savingsAmount = isSubscription && option.discountPercentage 
-            ? getSavingsAmount(originalPrice, option.discountPercentage)
-            : '0';
+          
+          // Fixed price per stick
+          const pricePerStick = isSubscription ? 1.09 : 1.56;
+          
+          // Calculate total based on sticks
+          const sticksPerTin = 15;
+          const totalSticks = quantity * sticksPerTin;
+          const totalPrice = totalSticks * pricePerStick;
+          
+          // For display purposes (crossed out price on subscription)
+          const oneTimeTotalPrice = totalSticks * 1.56;
+          
+          const savingsAmount = isSubscription 
+            ? oneTimeTotalPrice - totalPrice
+            : 0;
 
           return (
             <RadioGroup.Option
@@ -119,22 +128,25 @@ export default function SubscriptionSelectorV2({
                               {option.title}
                             </RadioGroup.Label>
                             <div className="flex items-center gap-2 mt-1">
-                              {isSubscription && option.discountPercentage ? (
+                              {isSubscription ? (
                                 <>
                                   <span className="text-gray-500 line-through text-base">
-                                    {formatPrice(originalPrice)}
+                                    ${oneTimeTotalPrice.toFixed(2)}
                                   </span>
-                                  <span className="text-lg font-semibold text-gray-900">
-                                    {formatPrice(discountedPrice)}
+                                  <span className="text-lg font-semibold text-emeraldgreen-500">
+                                    ${totalPrice.toFixed(2)}
                                   </span>
                                 </>
                               ) : (
                                 <>
-                                  <span className="text-lg font-semibold text-gray-900">
-                                    {formatPrice(originalPrice)}
+                                  <span className="text-lg font-semibold text-emeraldgreen-500">
+                                    ${totalPrice.toFixed(2)}
                                   </span>
                                 </>
                               )}
+                              <span className="text-xs text-gray-500">
+                                (${pricePerStick.toFixed(2)} / Stick)
+                              </span>
                             </div>
                           </div>
                         </div>
@@ -144,7 +156,7 @@ export default function SubscriptionSelectorV2({
                           <div className="space-y-2 mb-3">
                             <div className="flex items-center gap-2">
                               <CheckIcon className="w-4 h-4 text-emeraldgreen-600 flex-shrink-0" />
-                              <span className="text-sm text-gray-700">Save $11.88 per pack</span>
+                              <span className="text-sm text-gray-700">Save ${savingsAmount.toFixed(2)}</span>
                             </div>
                             <div className="flex items-center gap-2">
                               <CheckIcon className="w-4 h-4 text-emeraldgreen-600 flex-shrink-0" />


### PR DESCRIPTION
- Add QuantitySelector component for 1/2/3 tin selection (15/30/45 sticks)
- Restore quantity-based pricing in SubscriptionSelectorV2 ($1.09/stick subscription, $1.56/stick one-time)
- Fix AddToCartButton to accept external quantity instead of internal selector
- Update EnhancedProductForm to properly pass quantity between components
- Dynamic price updates: subscription shows crossed-out one-time price with savings
- Cart receives correct quantity and calculated total price

🤖 Generated with [Claude Code](https://claude.ai/code)