### PR TITLE
v0.1.2 chore: remove 48-pack tile from V3 PDP size selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to the Sunfruit storefront are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.2] - 2026-05-15
+
+### Changed
+- Product detail pages now show two purchase options instead of three: Sample and 1 Tin (24-pack). The 2 Tin (48-pack) tile was removed to simplify the discovery decision (Phase 1 of launch offer stack — Hick's Law cleanup).
+- Buyers who want 48 sticks can add the 24-pack to cart and increase the quantity. The 48-pack product itself remains live in Shopify and stays accessible to existing subscribers via the account portal.
+
 ## [0.1.1] - 2026-05-14
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ecommerce-shop",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/src/components/EnhancedProductFormV3.tsx
+++ b/src/components/EnhancedProductFormV3.tsx
@@ -35,7 +35,12 @@ export default function EnhancedProductFormV3({
   const router = useRouter();
   const searchParams = useSearchParams();
 
-  const [selectedSize, setSelectedSize] = useState<ProductSize>(initialSize);
+  // '48pack' is no longer a PDP-visible tile (Phase 1 of launch offer stack).
+  // Clamp incoming initialSize so direct-links to ?size=48pack don't land on
+  // a missing tile. The 48-pack product itself remains live in Shopify.
+  const [selectedSize, setSelectedSize] = useState<ProductSize>(
+    initialSize === '48pack' ? '24pack' : initialSize
+  );
   const [purchaseMode, setPurchaseMode] = useState<'subscription' | 'one-time'>('subscription');
 
   const flavorName = useMemo(() => getProductFlavorName(product), [product]);
@@ -51,7 +56,7 @@ export default function EnhancedProductFormV3({
 
   const availableSizes = useMemo(() => {
     return (Object.keys(productsBySize) as ProductSize[]).filter(s =>
-      s === 'sample' || s === '24pack' || s === '48pack'
+      s === 'sample' || s === '24pack'
     );
   }, [productsBySize]);
 
@@ -78,8 +83,7 @@ export default function EnhancedProductFormV3({
 
     const sizeOption = getSizeOption(selectedSize);
     const stickCount = sizeOption?.stickCount ?? 24;
-    const tinLabel =
-      selectedSize === '48pack' ? '2 Tins delivered monthly' : '1 Tin delivered monthly';
+    const tinLabel = '1 Tin delivered monthly';
     const basePrice = firstVariant?.priceV2?.amount;
 
     let monthlyDiscount = DEFAULT_MONTHLY_DISCOUNT;

--- a/src/components/SizeSelector3Cards.tsx
+++ b/src/components/SizeSelector3Cards.tsx
@@ -24,7 +24,7 @@ export default function SizeSelector3Cards({
         onChange={(option: SizeOption) => onChange(option.id)}
       >
         <RadioGroup.Label className="sr-only">Choose size</RadioGroup.Label>
-        <div className="grid grid-cols-3 gap-2 sm:gap-3">
+        <div className={`grid gap-2 sm:gap-3 ${displayOptions.length === 2 ? 'grid-cols-2' : 'grid-cols-3'}`}>
           {displayOptions.map((option) => (
             <RadioGroup.Option
               key={option.id}

--- a/src/lib/productUtils.ts
+++ b/src/lib/productUtils.ts
@@ -9,7 +9,10 @@ const FLAVOR_TAGS = ['lemon-mint', 'raspberry-hibiscus', 'grapefruit-ginger', 'b
 // Size type for the new product form.
 // '72pack' has no tile of its own in the 2-card layout — it's reachable only
 // via the 3-Month radio option inside SubscriptionMonthly3MonthCards.
-// '48pack' is a real, user-facing tile in the 3-card layout.
+// '48pack' is a real product (live in Shopify) but no longer rendered as a
+// PDP tile (Phase 1 of launch offer stack — Hick's Law cleanup). Existing
+// 48-pack subscriptions remain accessible via the account portal; new buyers
+// who want 48 sticks can add 24-pack with quantity 2 in the cart.
 export type ProductSize = 'sample' | '24pack' | '48pack' | '72pack';
 
 // SKU suffix to size mapping


### PR DESCRIPTION
## Summary
  
  Phase 1 of the launch offer stack: remove the 48-pack tile from the V3 product detail page. The PDP now shows two
  purchase options (Sample + 1 Tin / 24-pack) instead of three.

  **Why:** The 80% of buyers arriving on a Sunfruit PDP are one-time discovery shoppers. Three tiles created Hick's Law
  friction at the decision moment, and the 48-pack at $76.80 anchored the brand as expensive before the customer had
  tasted the product. Aligns with industry conventions (Athletic Greens, Liquid IV, LMNT all use 2-tile PDPs).
  
  **The 48-pack product is not gone** — it's still live in Shopify. Buyers who want 48 sticks can add 24-pack with
  quantity 2. Existing 48-pack subscribers retain access via the Recharge account portal.

  Per design doc:
  `~/.gstack/projects/tykykiro713-Sunfruit_Next.JS/tysonrohde-feature-pdp-remove-48pack-design-20260515-133504.md`

  ## Files changed

  - `src/components/EnhancedProductFormV3.tsx` — filter `'48pack'` from `availableSizes`, clamp `selectedSize` so
  direct-links to `?size=48pack` don't land on a missing tile, remove dead branch in `tinLabel`
  - `src/components/SizeSelector3Cards.tsx` — make `grid-cols` dynamic (renders 2 or 3 cards depending on
  `availableSizes.length`)
  - `src/lib/productUtils.ts` — update the `'48pack'` comment to reflect the new role (still a real Shopify product, no
  longer a PDP tile)

  ## Pre-Landing Review

  - **Typecheck:** clean (tsc --noEmit, 0 errors)
  - **Lint:** 142 problems vs 142 baseline on origin/main — zero regressions
  - **Adversarial check:** UI tile filtering only, no cart/checkout logic touched, account portal unaffected, Tailwind
  grid-cols-2 / grid-cols-3 both statically present in source for JIT
  - **Diff size:** 13 lines in 3 files — specialists skipped per /ship's <50 line rule

  ## Test plan

  - [ ] On the Vercel preview, navigate to a 24-pack product page (e.g. `/products/lemon-mint`) — should see Sample + 1
  Tin tiles only, no 48-pack tile
  - [ ] On the Vercel preview, direct-link to `/products/lemon-mint?size=48pack` — should render the 24-pack tile
  selected (the URL-side `?size=48pack` is a known cosmetic wart, not a bug)
  - [ ] Add 24-pack to cart, click + button to increase quantity to 2 — should work normally (validates the 48-stick
  workaround)
  - [ ] Verify existing 48-pack product page still renders if you have a SKU URL for it (the product itself is unchanged)
  - [ ] In Recharge account portal, confirm existing 48-pack subscriptions still appear as expected (out of scope for
  this PR but worth a quick smoke test)